### PR TITLE
Meaningful names

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,14 @@
 AllCops:
   Exclude:
-    - 'spec/spec_helper.rb'
     - 'Gemfile'
+    - 'spec/spec_helper.rb'
   NewCops: enable
 Metrics/BlockLength:
-  Enabled: false
+  Exclude:
+    - 'spec/*'
+    - 'spec_answers/*'
 Layout/LineLength:
-  Enabled: false
+  Exclude:
+    - 'spec/*'
+    - 'spec_answers/*'
   

--- a/contents.md
+++ b/contents.md
@@ -52,28 +52,34 @@ have_attributes\
 respond_to
 
 ## 12_magic_seven
-Arrange, Act & Assert testing pattern
+Arrange, Act & Assert testing pattern\
+disabling rubocop 
 
 ## 13_input_output
 Important to write small, isolated methods to test\
 Unnecessary to test puts and gets\
 Use 'gets methods' as parameters in another method that is tested\
 stubbing a method\
+creating new subjects & variables with meaningful names\
 before hooks\
+message expectations\
 output matcher
 
 ## 14_find_number
 TDD with doubles\
-Add method names to: subject { described_class.new.game_solution }
+Red-Green-Refactor\
+Creating a test subject, with a double as an argument\
+Add method names to: subject { described_class.new.solution }
 
 ## 15_binary_search
 Changing TDD Double to Instance Double\
-Stubbing a method\
+Determining what methods need to be tested in unit testing\
+instance_variable_get\
+Class Encapsulation\
 Polymorphism concept
 
 ## 16_caesar_breaker
 modules\
-mocking - assert before act\
 not_to raise_error\
 testing rescued error
 

--- a/lib/15a_binary_game.rb
+++ b/lib/15a_binary_game.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable Layout/LineLength
+
 # require_relative '../lib/15c_random_number'
 # require_relative '../lib/15b_binary_search'
 
@@ -97,3 +99,4 @@ class BinaryGame
     end
   end
 end
+# rubocop: enable Layout/LineLength

--- a/proposal.md
+++ b/proposal.md
@@ -7,13 +7,13 @@
 ## Summary
 
 The purpose of the 'RSpec Playground' is to equip students with additional practice before doing TDD with Connect Four. In addition, I believe students do not understand several important concepts, such as: 
-- The importance of writing small and isolated methods.
-- The benefits of using a testing pattern, such as 'Arrange Act, and Assert'.
-- The importance of class encapsulation
-- How to correctly use an explicit subject.
-- How to create different test conditions using a new instance with specific instance variable values.
-- How to use stubs, doubles, verifying doubles, etc.
-- How to determine what methods should be tested for good unit test coverage.
+- the importance of writing small and isolated methods
+- the benefits of using a testing pattern such as 'Arrange, Act, and Assert'
+- the importance of class encapsulation
+- how to correctly use an explicit subject
+- how to create different test conditions using a new instance with specific instance variable values
+- how to use stubs, doubles, verifying doubles, etc.
+- how to determine what methods should be tested for good unit test coverage
 
 ## Motivation
 
@@ -41,11 +41,11 @@ I searched for an alternative and could not find an better option than the Udemy
 
 ## Additional
 
-I have told a few people about this repo in the #ruby-testing channel. In addition, I have privately told a few students about it. At this time, I know that andrewjh271, aaron-contreras, tenacious-qi, msespos, and Pandenok have gone through them. 
+I have told a few people about this repo in the #ruby-testing channel. In addition, I have privately told a few students about it. At this time, I know that andrewjh271, aaron-contreras, tenacious-qi, msespos and Pandenok have viewed it. 
 
 This playground needs a thorough review by someone a lot more familiar with RSpec. Even though I have spent over three months learning RSpec, I do not feel 100% confident in some of my explanations & I have zero 'real-world' experience. 
 
-For example, the last two files focus on 'types' of methods that should always be tested. It was difficult to find useful information on what methods should be tested for these ruby games. Therefore, I combined information from Sandi Metz talk [Magic Tricks of Testing](https://www.youtube.com/watch?v=URSWYvyc42M), conversations in #ruby-testing, and even direct messages with Timato. 
+For example, the last two files focus on 'types' of methods that should always be tested. It was difficult to find useful information on what methods should be tested for these ruby games. Therefore I combined information from Sandi Metz talk [Magic Tricks of Testing](https://www.youtube.com/watch?v=URSWYvyc42M), conversations in #ruby-testing, and even direct messages with Timato. 
 
 ## Status
 - [x] Proposed

--- a/proposal.md
+++ b/proposal.md
@@ -7,12 +7,13 @@
 ## Summary
 
 The purpose of the 'RSpec Playground' is to equip students with additional practice before doing TDD with Connect Four. In addition, I believe students do not understand several important concepts, such as: 
-- Writing small and isolated methods.
-- Using a testing pattern, such as 'Arrange Act, and Assert'.
-- Correctly using an explicit subject.
-- How to create different test conditions
-- How to stub methods - either class methods or puts/gets (and that it can be unnecessary to test puts/gets).
-- How to use doubles, verifying doubles, etc.
+- The importance of writing small and isolated methods.
+- The benefits of using a testing pattern, such as 'Arrange Act, and Assert'.
+- The importance of class encapsulation
+- How to correctly use an explicit subject.
+- How to create different test conditions using a new instance with specific instance variable values.
+- How to use stubs, doubles, verifying doubles, etc.
+- How to determine what methods should be tested for good unit test coverage.
 
 ## Motivation
 
@@ -30,8 +31,6 @@ If students had additional practice using RSpec, specifically mocks and doubles,
 
 When I first started working on this 'playground', I imagined that it would be an additional resource in the [Testing Your Ruby Code lesson](https://www.theodinproject.com/courses/ruby-programming/lessons/testing-your-ruby-code). However, after talking with other people struggling with writing tests, I think it should be an assignment after writing tests for Caesar Cipher and before Tic Tac Toe. 
 
-In addition, I believe the Sandi Metz video should come before doing tests for Tic Tac Toe. I included a link in the second to file because it is very useful to teach what methods should & should not be tested. 
-
 ## Drawbacks
 
 The only drawback to adding this to the curriculum is that we may be answering more questions about these exercises. I have asked a few Odinites to work through these exercises to help me eliminate the typos and any confusing wording. 
@@ -42,11 +41,11 @@ I searched for an alternative and could not find an better option than the Udemy
 
 ## Additional
 
-I have told a few people about this repo in the #ruby-testing channel. In addition, I have privately told a few students about it. At this time, I know that andrewjh271, aaron-contreras, tenacious-qi, Natty, msespos, and Pandenok have or are currently going through them.
+I have told a few people about this repo in the #ruby-testing channel. In addition, I have privately told a few students about it. At this time, I know that andrewjh271, aaron-contreras, tenacious-qi, msespos, and Pandenok have gone through them. 
 
-This playground needs a thorough review by someone a lot more familiar with RSpec. Even though I have spent over two months learning RSpec, I do not feel 100% confident in some of my explanations & I have 0 'real-world' experience. 
+This playground needs a thorough review by someone a lot more familiar with RSpec. Even though I have spent over three months learning RSpec, I do not feel 100% confident in some of my explanations & I have zero 'real-world' experience. 
 
-For example, the last two files focus on methods that should be tested, based on Sandi Metz talk [Magic Tricks of Testing](https://www.youtube.com/watch?v=URSWYvyc42M). However, I am still uncertain of my understanding of this concept. In my tic-tac-toe game, I have several private methods in my Game class that handle crucial pieces of logic, such as `#player_turns` or `#switch_current_player`. However, these methods are only sent to self or are sending outgoing query messages. Based on my current understanding, these methods do not need to be tested. Having a thorough review by someone that is a lot more familiar with RSpec & Ruby would solidify my confidence in this RSpec playground. 
+For example, the last two files focus on 'types' of methods that should always be tested. It was difficult to find useful information on what methods should be tested for these ruby games. Therefore, I combined information from Sandi Metz talk [Magic Tricks of Testing](https://www.youtube.com/watch?v=URSWYvyc42M), conversations in #ruby-testing, and even direct messages with Timato. 
 
 ## Status
 - [x] Proposed

--- a/spec/12_magic_seven_spec.rb
+++ b/spec/12_magic_seven_spec.rb
@@ -21,7 +21,10 @@ require_relative '../lib/12_magic_seven'
 
 # NOTE: When you start using A-A-A to format your tests, it will feel
 # strange to not be following DRY (Don't Repeat Yourself). With tests, however,
-# repetition is necessary in order for them to be easy to read.
+# repetition is necessary in order for them to be easy to read. If you are using
+# rubocop, you can disable specific (or all) cops for certain files (or
+# directories) by adding a .rubocop.yml file.
+# https://docs.rubocop.org/rubocop/0.88/configuration.html#includingexcluding-files
 
 # When you start working on a existing code base, you will often become familiar
 # with the code by reading the tests.

--- a/spec/13_input_output_spec.rb
+++ b/spec/13_input_output_spec.rb
@@ -59,7 +59,13 @@ describe NumberGame do
   describe '#game_over?' do
     context 'when user guess is correct' do
       # To test this method, we need to set specific values for @solution and
-      # @guess, so we will create a new instance of NumberGame.
+      # @guess, so we will create a new instance of NumberGame. When creating
+      # another instance of NumberGame, we'll use a meaningful name to
+      # differentiate between instances.
+
+      # A helpful tip is to combine the purpose of the test and the object.
+      # E.g., game_end or complete_game.
+
       subject(:game_end) { described_class.new(5, '5') }
 
       it 'is game over' do
@@ -86,13 +92,13 @@ describe NumberGame do
   # Since we do not have to test #player_input, let's test #verify_input.
 
   describe '#verify_input' do
-    subject(:verify_game) { described_class.new }
+    subject(:game_check) { described_class.new }
     # Note: #verify_input will only return a value if it matches /^[0-9]$/
 
     context 'when given a valid input as argument' do
       it 'returns valid input' do
         user_input = '3'
-        verified_input = verify_game.verify_input(user_input)
+        verified_input = game_check.verify_input(user_input)
         expect(verified_input).to eq('3')
       end
     end
@@ -114,7 +120,7 @@ describe NumberGame do
     # https://relishapp.com/rspec/rspec-mocks/v/2-14/docs/method-stubs/allow-with-a-simple-return-value
     # http://testing-for-beginners.rubymonstas.org/test_doubles.html
 
-    subject(:player_game) { described_class.new }
+    subject(:game_loop) { described_class.new }
 
     context 'when user input is valid' do
       # To test the behavior, we want to test that the loop stops before the
@@ -124,10 +130,10 @@ describe NumberGame do
 
       it 'stops loop and does not display error message' do
         valid_input = '3'
-        allow(player_game).to receive(:player_input).and_return(valid_input)
+        allow(game_loop).to receive(:player_input).and_return(valid_input)
         # To use a message expectation, move 'Assert' before 'Act'.
-        expect(player_game).not_to receive(:puts).with('Input error!')
-        player_game.player_turn
+        expect(game_loop).not_to receive(:puts).with('Input error!')
+        game_loop.player_turn
       end
     end
 
@@ -144,15 +150,15 @@ describe NumberGame do
       before do
         letter = 'd'
         valid_input = '8'
-        allow(player_game).to receive(:player_input).and_return(letter, valid_input)
+        allow(game_loop).to receive(:player_input).and_return(letter, valid_input)
       end
 
       # When using message expectations, you can specify how many times you
       # expect the message to be received.
       # https://relishapp.com/rspec/rspec-mocks/docs/setting-constraints/receive-counts
       it 'completes loop and displays error message once' do
-        expect(player_game).to receive(:puts).with('Input error!').once
-        player_game.player_turn
+        expect(game_loop).to receive(:puts).with('Input error!').once
+        game_loop.player_turn
       end
     end
 

--- a/spec/14_find_number_spec.rb
+++ b/spec/14_find_number_spec.rb
@@ -17,11 +17,10 @@ require_relative '../lib/14_find_number'
 
 # In this lesson, we will be testing the class 'FindNumber'. Look at the
 # lib/14_find_number.rb file. An instance of 'FindNumber' is initialized with
-# a 'RandomNumber' object (unless a third argument is given to the initialize
-# method).
+# min, max, answer and guess. There are default values for answer and guess.
 
-# The 'RandomNumber' class has not been written, so we will use a double for it
-# in these tests.
+# Note: the 'RandomNumber' class has not been written. During TDD, we will need
+# to create a double for RandomNumber in the tests for FindNumber.
 # https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/basics/test-doubles
 
 # Learning about doubles can be very confusing, because many resources use
@@ -84,7 +83,7 @@ describe FindNumber do
 end
 
 # ASSIGNMENT
-# For this assignment you will be doing TDD for 3 methods: #make_guess,
+# For this lesson you will be doing TDD for 3 methods: #make_guess,
 # #game_over?, and #update_range.
 
 # After you have some experience using TDD, you can use the typical
@@ -112,10 +111,11 @@ describe FindNumber do
   # The computer will update min and max values to help find the correct number.
 
   describe '#make_guess' do
-    # Create a random_number double & allow it to receive 'value' and return any
-    # number between 0 and 9, in one of the two ways explained above.
+    # Create a random_number double called 'number_guessing'. Allow the double
+    # to receive 'value' and return the value of 8, in one of the two ways
+    # explained above.
 
-    subject(:game) { described_class.new(0, 9, random_number) }
+    subject(:game_guessing) { described_class.new(0, 9, number_guessing) }
 
     # Before you write the #make_guess method:
     # Write a test that would expect #make_guess to return the average of
@@ -130,39 +130,45 @@ describe FindNumber do
     # the average of the min and max values (rounded down).
     # You can now run the above test and it should pass.
 
-    # Write a test for each of the following contexts:
+    # Write a test for each of the following contexts. You will need to create a
+    # new instance of FindNumber for each context, but you can use the same
+    # random number double created inside this method's describe block.
 
     context 'when min is 5 and max is 9' do
+      xit 'returns 7' do
+      end
     end
 
     context 'when min is 8 and max is 9' do
+      xit 'returns 8' do
+      end
     end
 
     context 'when min is 0 and max is 3' do
+      xit 'returns 1' do
+      end
     end
 
     context 'when min and max both equal 3' do
+      xit 'returns 3' do
+      end
     end
   end
 
   # ASSIGNMENT: METHOD #2
   describe '#game_over?' do
-    # In a long test file, it can be helpful to declare variables in each
-    # describe block, to make the tests more readable. When creating another
-    # instance of the random number and/or subject, use a meaningful name to
-    # differentiate between instances.
-
-    # Create a subject and random_number double with meaningful names.
-    # A helpful tip is to combine the purpose of the test and the object.
-    # E.g., ending_number & ending_game or completing_random & completing_game.
-
-    # Allow the double to receive 'value' and return a number from 0 to 9.
-
-    # Write a test that would expect game to be_game_over when a guess equals
-    # the random_number double's value above. Remember that this test will not
-    # be able to pass yet because you haven't written the method!
-
     context 'when guess and random_number are equal' do
+      # Create another subject and random_number double with meaningful names.
+      # The subject will need to specify the number value of @guess.
+
+      # Allow the double to receive 'value' and return the same number as @guess.
+
+      # Write a test that would expect game to be_game_over when a guess equals
+      # the random_number double's value above. Remember that this test will not
+      # be able to pass yet because you haven't written the method!
+
+      xit 'is game over' do
+      end
     end
 
     # Write the corresponding method in 14_find_number.rb called #game_over?
@@ -172,14 +178,16 @@ describe FindNumber do
     # NOT equal the random_number double's value above.
 
     context 'when guess and random_number are not equal' do
+      xit 'is not game over' do
+      end
     end
   end
 
   # ASSIGNMENT: METHOD #3
   describe '#update_range' do
-    # If you share the same random_number double for both multiple context
-    # blocks, you can declare it inside the describe block.
-    let(:range_number) { double('random_number', value: 8) }
+    # As you have seen above, you can share the same random_number double for
+    # multiple context blocks, by declaring it inside the describe block.
+    let(:number_range) { double('random_number', value: 8) }
 
     # Write four tests for #update_range that test the values of min and max.
 
@@ -191,17 +199,10 @@ describe FindNumber do
     # - min stays the same
     # - max updates to one less than the guess
 
-    # Note: updating_game in each context block starts off with
-    # min = 0 and max = 9.
-
     context 'when the guess is less than the answer' do
-      subject(:low_guess_game) { described_class.new(0, 9, range_number, 4) }
+      subject(:low_guess_game) { described_class.new(0, 9, number_range, 4) }
 
-      before do
-        low_guess_game.update_range
-      end
-
-      xit 'updates min' do
+      xit 'updates min to 5' do
       end
 
       xit 'does not update max' do
@@ -209,10 +210,12 @@ describe FindNumber do
     end
 
     context 'when the guess is more than the answer' do
+      subject(:high_guess_game) { described_class.new(0, 9, number_range, 9) }
+
       xit 'does not update min' do
       end
 
-      xit 'updates max' do
+      xit 'updates max to 8' do
       end
     end
 

--- a/spec_answers/12_magic_seven_answer.rb
+++ b/spec_answers/12_magic_seven_answer.rb
@@ -21,7 +21,10 @@ require_relative '../lib/12_magic_seven'
 
 # NOTE: When you start using A-A-A to format your tests, it will feel
 # strange to not be following DRY (Don't Repeat Yourself). With tests, however,
-# repetition is necessary in order for them to be easy to read.
+# repetition is necessary in order for them to be easy to read. If you are using
+# rubocop, you can disable specific (or all) cops for certain files (or
+# directories) by adding a .rubocop.yml file.
+# https://docs.rubocop.org/rubocop/0.88/configuration.html#includingexcluding-files
 
 # When you start working on a existing code base, you will often become familiar
 # with the code by reading the tests.

--- a/spec_answers/13_input_output_answer.rb
+++ b/spec_answers/13_input_output_answer.rb
@@ -62,7 +62,13 @@ describe NumberGame do
   describe '#game_over?' do
     context 'when user guess is correct' do
       # To test this method, we need to set specific values for @solution and
-      # @guess, so we will create a new instance of NumberGame.
+      # @guess, so we will create a new instance of NumberGame. When creating
+      # another instance of NumberGame, we'll use a meaningful name to
+      # differentiate between instances.
+
+      # A helpful tip is to combine the purpose of the test and the object.
+      # E.g., game_end or complete_game.
+
       subject(:game_end) { described_class.new(5, '5') }
 
       it 'is game over' do
@@ -92,13 +98,13 @@ describe NumberGame do
   # Since we do not have to test #player_input, let's test #verify_input.
 
   describe '#verify_input' do
-    subject(:verify_game) { described_class.new }
+    subject(:game_check) { described_class.new }
     # Note: #verify_input will only return a value if it matches /^[0-9]$/
 
     context 'when given a valid input as argument' do
       it 'returns valid input' do
         user_input = '3'
-        verified_input = verify_game.verify_input(user_input)
+        verified_input = game_check.verify_input(user_input)
         expect(verified_input).to eq('3')
       end
     end
@@ -109,7 +115,7 @@ describe NumberGame do
     context 'when given invalid input as argument' do
       it 'returns nil' do
         letter_input = 'g'
-        verified_input = verify_game.verify_input(letter_input)
+        verified_input = game_check.verify_input(letter_input)
         expect(verified_input).to be_nil
       end
     end
@@ -123,7 +129,7 @@ describe NumberGame do
     # https://relishapp.com/rspec/rspec-mocks/v/2-14/docs/method-stubs/allow-with-a-simple-return-value
     # http://testing-for-beginners.rubymonstas.org/test_doubles.html
 
-    subject(:player_game) { described_class.new }
+    subject(:game_loop) { described_class.new }
 
     context 'when user input is valid' do
       # To test the behavior, we want to test that the loop stops before the
@@ -133,10 +139,10 @@ describe NumberGame do
 
       it 'stops loop and does not display error message' do
         valid_input = '3'
-        allow(player_game).to receive(:player_input).and_return(valid_input)
+        allow(game_loop).to receive(:player_input).and_return(valid_input)
         # To use a message expectation, move 'Assert' before 'Act'.
-        expect(player_game).not_to receive(:puts).with('Input error!')
-        player_game.player_turn
+        expect(game_loop).not_to receive(:puts).with('Input error!')
+        game_loop.player_turn
       end
     end
 
@@ -153,15 +159,15 @@ describe NumberGame do
       before do
         letter = 'd'
         valid_input = '8'
-        allow(player_game).to receive(:player_input).and_return(letter, valid_input)
+        allow(game_loop).to receive(:player_input).and_return(letter, valid_input)
       end
 
       # When using message expectations, you can specify how many times you
       # expect the message to be received.
       # https://relishapp.com/rspec/rspec-mocks/docs/setting-constraints/receive-counts
       it 'completes loop and displays error message once' do
-        expect(player_game).to receive(:puts).with('Input error!').once
-        player_game.player_turn
+        expect(game_loop).to receive(:puts).with('Input error!').once
+        game_loop.player_turn
       end
     end
 
@@ -173,12 +179,12 @@ describe NumberGame do
         letter = 'd'
         symbol = '$'
         valid_input = '2'
-        allow(player_game).to receive(:player_input).and_return(letter, symbol, valid_input)
+        allow(game_loop).to receive(:player_input).and_return(letter, symbol, valid_input)
       end
 
       it 'completes loop and displays error message twice' do
-        expect(player_game).to receive(:puts).with('Input error!').twice
-        player_game.player_turn
+        expect(game_loop).to receive(:puts).with('Input error!').twice
+        game_loop.player_turn
       end
     end
   end

--- a/spec_answers/14_find_number_answer.rb
+++ b/spec_answers/14_find_number_answer.rb
@@ -27,8 +27,9 @@ class FindNumber
   end
 end
 
+# ASSIGNMENT
 # For this lesson you will be doing TDD for 3 methods: #make_guess,
-# #make_guess, and #update_range.
+# #game_over?, and #update_range.
 
 # After you have some experience using TDD, you can use the typical
 # Red-Green-Refactor workflow.
@@ -55,11 +56,12 @@ describe FindNumber do
   # The computer will update min and max values to help find the correct number.
 
   describe '#make_guess' do
-    # Create a random_number double & allow it to receive 'value' and return any
-    # number between 0 and 9, in one of the two ways explained above.
+    # Create a random_number double called 'number_guessing'. Allow the double
+    # to receive 'value' and return the value of 8, in one of the two ways
+    # explained above.
 
-    let(:random_number) { double('random_number', value: 8) }
-    subject(:game) { described_class.new(0, 9, random_number) }
+    let(:number_guessing) { double('random_number', value: 8) }
+    subject(:game_guessing) { described_class.new(0, 9, number_guessing) }
 
     # Before you write the #make_guess method:
     # Write a test that would expect #make_guess to return the average of
@@ -67,7 +69,7 @@ describe FindNumber do
     # able to pass as you haven't written #make_guess yet!
     context 'when min is 0 and max is 9' do
       it 'returns 4' do
-        guess = game.make_guess
+        guess = game_guessing.make_guess
         expect(guess).to eq(4)
       end
     end
@@ -76,10 +78,12 @@ describe FindNumber do
     # the average of the min and max values (rounded down).
     # You can now run the above test and it should pass.
 
-    # Write a test for each of the following contexts:
+    # Write a test for each of the following contexts. You will need to create a
+    # new instance of FindNumber for each context, but you can use the same
+    # random number double created inside this method's describe block.
 
     context 'when min is 5 and max is 9' do
-      subject(:game_five) { described_class.new(5, 9, random_number) }
+      subject(:game_five) { described_class.new(5, 9, number_guessing) }
 
       it 'returns 7' do
         guess = game_five.make_guess
@@ -88,7 +92,7 @@ describe FindNumber do
     end
 
     context 'when min is 8 and max is 9' do
-      subject(:game_eight) { described_class.new(8, 9, random_number) }
+      subject(:game_eight) { described_class.new(8, 9, number_guessing) }
 
       it 'returns 8' do
         guess = game_eight.make_guess
@@ -97,7 +101,7 @@ describe FindNumber do
     end
 
     context 'when min is 0 and max is 3' do
-      subject(:game_zero) { described_class.new(0, 3, random_number) }
+      subject(:game_zero) { described_class.new(0, 3, number_guessing) }
 
       it 'returns 1' do
         guess = game_zero.make_guess
@@ -106,7 +110,7 @@ describe FindNumber do
     end
 
     context 'when min and max both equal 3' do
-      subject(:game_three) { described_class.new(3, 3, random_number) }
+      subject(:game_three) { described_class.new(3, 3, number_guessing) }
 
       it 'returns 3' do
         guess = game_three.make_guess
@@ -117,27 +121,21 @@ describe FindNumber do
 
   # ASSIGNMENT: METHOD #2
   describe '#game_over?' do
-    # In a long test file, it can be helpful to declare variables in each
-    # describe block, to make the tests more readable. When creating another
-    # instance of the random number and/or subject, use a meaningful name to
-    # differentiate between instances.
-
-    # Create a subject and random_number double with meaningful names.
-    # A helpful tip is to combine the purpose of the test and the object.
-    # E.g., ending_number & ending_game or completing_random & completing_game.
-
-    # Allow the double to receive 'value' and return a number from 0 to 9.
-
-    # Write a test that would expect game to be_game_over when a guess equals
-    # the random_number double's value above. Remember that this test will not
-    # be able to pass yet because you haven't written the method!
-
     context 'when guess and random_number are equal' do
-      let(:ending_number) { double('random_number', value: 3) }
-      subject(:ending_game) { described_class.new(0, 9, ending_number, 3) }
+      # Create another subject and random_number double with meaningful names.
+      # The subject will need to specify the number value of @guess.
+
+      # Allow the double to receive 'value' and return the same number as @guess.
+
+      # Write a test that would expect game to be_game_over when a guess equals
+      # the random_number double's value above. Remember that this test will not
+      # be able to pass yet because you haven't written the method!
+
+      let(:number_end) { double('random_number', value: 3) }
+      subject(:game_end) { described_class.new(0, 9, number_end, 3) }
 
       it 'is game over' do
-        expect(ending_game).to be_game_over
+        expect(game_end).to be_game_over
       end
     end
 
@@ -148,20 +146,20 @@ describe FindNumber do
     # NOT equal the random_number double's value above.
 
     context 'when guess and random_number are not equal' do
-      let(:mid_number) { double('random_number', value: 5) }
-      subject(:mid_game) { described_class.new(0, 9, mid_number, 4) }
+      let(:number_mid) { double('random_number', value: 5) }
+      subject(:game_mid) { described_class.new(0, 9, number_mid, 4) }
 
       it 'is not game over' do
-        expect(mid_game).to_not be_game_over
+        expect(game_mid).to_not be_game_over
       end
     end
   end
 
   # ASSIGNMENT: METHOD #3
   describe '#update_range' do
-    # If you share the same random_number double for both multiple context
-    # blocks, you can declare it inside the describe block.
-    let(:range_number) { double('random_number', value: 8) }
+    # As you have seen above, you can share the same random_number double for
+    # multiple context blocks, by declaring it inside the describe block.
+    let(:number_range) { double('random_number', value: 8) }
 
     # Write four tests for #update_range that test the values of min and max.
 
@@ -173,17 +171,14 @@ describe FindNumber do
     # - min stays the same
     # - max updates to one less than the guess
 
-    # Note: updating_game in each context block starts off with
-    # min = 0 and max = 9.
-
     context 'when the guess is less than the answer' do
-      subject(:low_guess_game) { described_class.new(0, 9, range_number, 4) }
+      subject(:low_guess_game) { described_class.new(0, 9, number_range, 4) }
 
       before do
         low_guess_game.update_range
       end
 
-      it 'updates min' do
+      it 'updates min to 5' do
         minimum = low_guess_game.min
         expect(minimum).to eq(5)
       end
@@ -195,7 +190,7 @@ describe FindNumber do
     end
 
     context 'when the guess is more than the answer' do
-      subject(:high_guess_game) { described_class.new(0, 9, range_number, 9) }
+      subject(:high_guess_game) { described_class.new(0, 9, number_range, 9) }
 
       before do
         high_guess_game.update_range
@@ -206,7 +201,7 @@ describe FindNumber do
         expect(minimum).to eq(0)
       end
 
-      it 'updates max' do
+      it 'updates max to 8' do
         maximum = high_guess_game.max
         expect(maximum).to eq(8)
       end
@@ -224,19 +219,19 @@ describe FindNumber do
     # Write a test for any 'edge cases' that you can think of, for example:
 
     context 'when the guess is 7, with min=5 and max=8' do
-      subject(:eight_game) { described_class.new(5, 8, range_number, 7) }
+      subject(:game_range) { described_class.new(5, 8, number_range, 7) }
 
       before do
-        eight_game.update_range
+        game_range.update_range
       end
 
       it 'updates min to the same value as max' do
-        minimum = eight_game.min
+        minimum = game_range.min
         expect(minimum).to eq(8)
       end
 
       it 'does not update max' do
-        maximum = eight_game.max
+        maximum = game_range.max
         expect(maximum).to eq(8)
       end
     end


### PR DESCRIPTION
This PR moves the explanation of having meaningful subjects & let variable names to lesson 13, since that is the first place it is used. Added an explanation about using a .rubocop.yml file to ignore spec files, updated the proposal & lesson contents list.